### PR TITLE
Fix: Remove double, or more, slashes in navigation links from the new tab page. (commit from joaoiacillo)

### DIFF
--- a/src/renderer/pages/BrowserPage/newTabItems.ts
+++ b/src/renderer/pages/BrowserPage/newTabItems.ts
@@ -23,25 +23,28 @@ export const newTabPrimaryItems = [
   },
 ];
 
+const createItchioUrl = (path: string) =>
+  `${urls.itchio}/${path}`.replace(/(?<!:)\/\/+/g, "/");
+
 export const newTabSecondaryItems = [
   {
     label: ["new_tab.random"],
     icon: "shuffle",
-    url: urls.itchio + "/randomizer",
+    url: createItchioUrl("randomizer"),
   },
   {
     label: ["new_tab.on_sale"],
     icon: "shopping_cart",
-    url: urls.itchio + "/games/on-sale",
+    url: createItchioUrl("games/on-sale"),
   },
   {
     label: ["new_tab.top_sellers"],
     icon: "star",
-    url: urls.itchio + "/games/top-sellers",
+    url: createItchioUrl("games/top-sellers"),
   },
   {
     label: ["new_tab.devlogs"],
     icon: "fire",
-    url: urls.itchio + "/devlogs",
+    url: createItchioUrl("devlogs"),
   },
 ];


### PR DESCRIPTION
Resolved issue where links navigated users to "itch.io//path", causing incorrect behavior. Adjusted link generation to ensure proper URL formatting.